### PR TITLE
add a newline between merged files

### DIFF
--- a/contributions/jcssmanager/behaviour/commands/jcssmanager/yui/compress.base.cmd.php
+++ b/contributions/jcssmanager/behaviour/commands/jcssmanager/yui/compress.base.cmd.php
@@ -38,6 +38,7 @@ class JCSSManagerCompressBaseYuiCommand extends JCSSManagerCompressBaseCommand {
 					$file = Config::get_value(Config::URL_ABSPATH) . $file;
 				}
 				fwrite($handle, $this->get_file_contents($file));
+				fwrite($handle, "\n");
 			}			
 			fclose($handle);
 		}


### PR DESCRIPTION
When merging already compressed js files it is not always guaranteed that the last line in ends with a newline. 
If the last line is a single-line comment, the next file will be added right there continued as a comment.