### PR TITLE
load confirmations model on user lost-password

### DIFF
--- a/contributions/usermanagement/model/classes/users.facade.php
+++ b/contributions/usermanagement/model/classes/users.facade.php
@@ -379,6 +379,7 @@ class Users {
 		$user->email = $email;
 		$user->status = self::STATUS_ACTIVE;
 		if ($email && $user->find(IDataObject::AUTOFETCH)) {
+            Load::models('confirmations');
 			$params = array(
 				'id_item' => $user->id,
 				'action' => 'onetimelogin',


### PR DESCRIPTION
If gyro-php is used with composer and vendor autoload, auto loading models is not available.