### PR TITLE
load model confirmations before using it

### DIFF
--- a/contributions/usermanagement/behaviour/commands/base/updateusers.cmd.php
+++ b/contributions/usermanagement/behaviour/commands/base/updateusers.cmd.php
@@ -110,6 +110,8 @@ class UpdateUsersBaseCommand extends CommandChain {
 	 * @since 0.5.1
 	 */
 	protected function send_email_notification($user, $email) {
+        Load::models('confirmations');
+        
 		// Indirectly change mail, if desired
 		$params = array(
 			'id_item' => $user->id,


### PR DESCRIPTION
weird, I had the following error while using „normal“ password recovery link:

PHP Fatal error:
Uncaught Error: Class 'DAOConfirmations' not found in /var/www/_include/gyro-php/contributions/confirmations/behaviour/commands/confirmations/create.cmd.php:16
Stack trace:
#0 /var/www/_include/gyro-php/gyro/core/behaviour/base/commandchain.cls.php(52): CreateConfirmationsCommand->do_execute()
#1 /var/www/_include/gyro-php/gyro/core/behaviour/base/commandchain.cls.php(56): CommandChain->execute()
#2 /var/www/_include/gyro-php/contributions/usermanagement/model/classes/users.facade.php(217): CommandChain->execute()
#3 /var/www/_include/gyro-php/contributions/usermanagement/controller/base/user.basecontroller.php(385): Users::update(Object(DAOUsers), Array)
#4 /var/www/_include/gyro-php/contributions/usermanagement/controller/base/user.basecontroller.php(369): UserBaseController->do_lost_password_reenter(Object(FormHandler), Object(PageData), '620d10088122175...')
#5 /var/www/_include/gyro-php/gyro/core/controller/base/routes/parameterizedroute.cls.php(379): UserBaseController->action_lost_password_reenter(Obje in /var/www/_include/gyro-php/contributions/confirmations/behaviour/commands/confirmations/create.cmd.php

I used password-recovery in other projects already without problems ... maybe it is PHP7 related?