### PR TITLE
add policy to DBFilterGroup for session based filter storage

### DIFF
--- a/gyro/core/controller/tools/filtertext.cls.php
+++ b/gyro/core/controller/tools/filtertext.cls.php
@@ -141,3 +141,24 @@ class FilterTextDefaultAdapter implements IFilterTextAdapter {
 	}	
 }
 
+/**
+ * Optional Implementation to remember filter value in session
+ *
+ * @author Heiko Weber
+ * @ingroup Controller
+ */
+class FilterTextSessionAdapter extends FilterTextDefaultAdapter {
+    
+	public function get_value() {
+        $param = $this->get_param();
+        $default_value = '';
+        $session_param = 'flttxt'.$param;
+        if (isset($_SESSION[$session_param])) {
+            $default_value = $_SESSION[$session_param];
+        }
+		$reset = $this->page_data->get_get()->contains($this->get_reset_param());
+		$return_value = ($reset) ? '' : $this->page_data->get_get()->get_item($param, $default_value);
+        $_SESSION[$session_param] = $return_value;
+        return $return_value;
+	}
+}

--- a/gyro/core/model/base/dbfiltergroup.cls.php
+++ b/gyro/core/model/base/dbfiltergroup.cls.php
@@ -9,9 +9,6 @@ require_once dirname(__FILE__) . '/dbfilter.cls.php';
  * @ingroup Model
  */
 class DBFilterGroup implements IDBQueryModifier {
-    const FILTER_POLICY_GET_URL = 0;
-    const FILTER_POLICY_SESSION = 1;
-    
 	/**
 	 * An associative array of DBFilter instances 
 	 */
@@ -20,26 +17,18 @@ class DBFilterGroup implements IDBQueryModifier {
 	protected $group_key = ''; 
 	protected $key_default_filter = '';
 	protected $key_current_filter = '';
-    protected $policy;
 	
 	/**
 	 * Constructor
 	 * 
 	 * @param array Associative array of DBFilter instances
 	 */
-	public function __construct($key = '', $name = '', $filters = array(), $default = '', $policy = self::FILTER_POLICY_GET_URL) {
+	public function __construct($key = '', $name = '', $filters = array(), $default = '') {
 		$this->name = $name;
 		$this->group_key = $key;
 		foreach($filters as $key => $value) {
 			$this->add_filter(strval($key), $value);
 		}
-        $this->policy = $policy;
-        if ($policy == self::FILTER_POLICY_SESSION) {
-            $lookup = $this->get_session_lookup_str();
-            if ($lookup !== false && isset($_SESSION[$lookup])) {
-                $default = $_SESSION[$lookup];
-            }
-        }
 		$this->set_default_key($default);
 		$this->set_current_key($default);
 	}
@@ -119,13 +108,6 @@ class DBFilterGroup implements IDBQueryModifier {
 	 */
 	public function set_current_key($key) {
 		$this->key_current_filter = $key;
-        
-        if ($this->policy == self::FILTER_POLICY_SESSION) {
-            $lookup = $this->get_session_lookup_str();
-            if ($lookup !== false) {
-                $_SESSION[$lookup] = $key;
-            }
-        }
 	}
 
 	/**
@@ -154,8 +136,4 @@ class DBFilterGroup implements IDBQueryModifier {
 	public function apply($query) {
 		$query->apply_modifier($this->get_current_filter());
 	}
-
-    protected function get_session_lookup_str() {
-        return 'filter_'.Url::current()->clear_query()->__toString().$this->get_name();
-    }
 }

--- a/gyro/core/model/base/dbfiltergroup.cls.php
+++ b/gyro/core/model/base/dbfiltergroup.cls.php
@@ -9,6 +9,9 @@ require_once dirname(__FILE__) . '/dbfilter.cls.php';
  * @ingroup Model
  */
 class DBFilterGroup implements IDBQueryModifier {
+    const FILTER_POLICY_GET_URL = 0;
+    const FILTER_POLICY_SESSION = 1;
+    
 	/**
 	 * An associative array of DBFilter instances 
 	 */
@@ -17,18 +20,26 @@ class DBFilterGroup implements IDBQueryModifier {
 	protected $group_key = ''; 
 	protected $key_default_filter = '';
 	protected $key_current_filter = '';
+    protected $policy;
 	
 	/**
 	 * Constructor
 	 * 
 	 * @param array Associative array of DBFilter instances
 	 */
-	public function __construct($key = '', $name = '', $filters = array(), $default = '') {
+	public function __construct($key = '', $name = '', $filters = array(), $default = '', $policy = self::FILTER_POLICY_GET_URL) {
 		$this->name = $name;
 		$this->group_key = $key;
 		foreach($filters as $key => $value) {
 			$this->add_filter(strval($key), $value);
 		}
+        $this->policy = $policy;
+        if ($policy == self::FILTER_POLICY_SESSION) {
+            $lookup = $this->get_session_lookup_str();
+            if ($lookup !== false && isset($_SESSION[$lookup])) {
+                $default = $_SESSION[$lookup];
+            }
+        }
 		$this->set_default_key($default);
 		$this->set_current_key($default);
 	}
@@ -108,6 +119,13 @@ class DBFilterGroup implements IDBQueryModifier {
 	 */
 	public function set_current_key($key) {
 		$this->key_current_filter = $key;
+        
+        if ($this->policy == self::FILTER_POLICY_SESSION) {
+            $lookup = $this->get_session_lookup_str();
+            if ($lookup !== false) {
+                $_SESSION[$lookup] = $key;
+            }
+        }
 	}
 
 	/**
@@ -136,4 +154,8 @@ class DBFilterGroup implements IDBQueryModifier {
 	public function apply($query) {
 		$query->apply_modifier($this->get_current_filter());
 	}
+
+    protected function get_session_lookup_str() {
+        return 'filter_'.Url::current()->clear_query()->__toString().$this->get_name();
+    }
 }


### PR DESCRIPTION
There is a „save current filters“ in SESSION on the ToDo list.

Although the current modification seems to allow it, it is not perfect, because it only saves filter values for a single Url - ideally it should grab the current action, so /foo/bar/4/list and /foo/bar/6/list could share saved filter values.

But how to achieve it? Feel free to comment or improve.