### PR TITLE
address utf8 / utf8mb4 issue on table sessions …

### DIFF
--- a/gyro/core/config.cls.php
+++ b/gyro/core/config.cls.php
@@ -48,6 +48,11 @@ class Config {
 	const LOG_TRANSLATIONS = 'LOG_TRANSLATIONS';
 	const LOG_HTML_ERROR_STATUS = 'LOG_HTML_ERROR_STATUS';
 	const LOG_HTTPREQUESTS = 'LOG_HTTPREQUESTS';
+    /**
+     * DB UTF8 / UTF8MB4
+     */
+    const DB_USE_UTF8MB4_ON_UTF8 = 'DB_USE_UTF8MB4_ON_UTF8';
+    const DB_TR_UTF8_TO_UTF8MB4 = 'DB_TR_UTF8_TO_UTF8MB4';
 	/**
 	 * Added to each email subject line
 	 */

--- a/gyro/core/constants.inc.php
+++ b/gyro/core/constants.inc.php
@@ -173,6 +173,12 @@ Config::set_value_from_constant(Config::QUERY_PARAM_PATH_INVOKED, 'APP_QUERY_PAR
 Config::set_value_from_constant(Config::DB_SLOW_QUERY_THRESHOLD, 'APP_DB_SLOW_QUERY_THRESHOLD', 0.0100);
 
 /**
+ * DB UTF8 / UTF8MB4
+ */
+Config::set_value_from_constant(Config::DB_USE_UTF8MB4_ON_UTF8, 'APP_DB_USE_UTF8MB4_ON_UTF8', false);
+Config::set_value_from_constant(Config::DB_TR_UTF8_TO_UTF8MB4, 'APP_DB_TR_UTF8_TO_UTF8MB4', false);
+
+/**
  * Cache headers
  */
 Config::set_value_from_constant(Config::CACHEHEADER_CLASS_CACHED, 'APP_CACHEHEADER_CLASS_CACHED', 'PrivateRigid');

--- a/gyro/core/model/drivers/mysql/dbdriver.mysql.php
+++ b/gyro/core/model/drivers/mysql/dbdriver.mysql.php
@@ -102,7 +102,11 @@ class DBDriverMysql implements IDBDriver {
 			if ($err->is_ok()) {
 				// We are connected
 				if (GyroLocale::get_charset() == 'UTF-8') {
-					$this->execute("SET NAMES 'utf8' COLLATE 'utf8_general_ci'");
+                    if (Config::has_feature(Config::DB_USE_UTF8MB4_ON_UTF8)) {
+                        $this->execute("SET NAMES 'utf8mb4' COLLATE 'utf8mb4_general_ci'");
+                    } else {
+                        $this->execute("SET NAMES 'utf8' COLLATE 'utf8_general_ci'");
+                    }
 				}
 				//$this->execute("SET sql_mode=STRICT_ALL_TABLES");
 				$this->execute("SET sql_mode='TRADITIONAL'");


### PR DESCRIPTION
when session data with 4 byte UTF-8 characters is saved into mysql 3-byte ‚utf8‘ charset data field.
There are two options:
- APP_ DB_USE_UTF8MB4_ON_UTF8 uses
SET NAMES 'utf8mb4' COLLATE 'utf8mb4_general_ci‘
- APP_DB_TR_UTF8_TO_UTF8MB4
  + has to be used in addition to APP_DB_USE_UTF8MB4_ON_UTF8
  + could auto-convert charset and collates to utf8mb4 - but is restricted yet to only the session table (due the 768 byte limit of indexes, which get exceeded on other system tables).
  + This option doesn’t help on a already created session table, you have to convert it manually.