### PR TITLE
confirmations: set table charset to utf8 on install

### DIFF
--- a/contributions/confirmations/install/install.sql
+++ b/contributions/confirmations/install/install.sql
@@ -8,4 +8,4 @@ CREATE TABLE IF NOT EXISTS `confirmations` (
   PRIMARY KEY (`id`),
   UNIQUE INDEX `iu_confirmations`(`id_item`, `code`)
 )
-ENGINE = InnoDB;
+ENGINE = InnoDB CHARSET=utf8;


### PR DESCRIPTION
I’ve excluded to alter existing tables in an update … not sure if it would break something.