### PR TITLE
Ensure the breadcrump is always html escaped when translated

### DIFF
--- a/contributions/deletedialog/view/templates/default/deletedialog/approve.tpl.php
+++ b/contributions/deletedialog/view/templates/default/deletedialog/approve.tpl.php
@@ -10,7 +10,7 @@ $page_data->head->title = $title;
 $page_data->breadcrumb = WidgetBreadcrumb::output(
 	array(
 		$instance,
-		tr('Delete', 'deletedialog')
+		GyroString::escape(tr('Delete', 'deletedialog'))
 	)
 );
 ?>

--- a/contributions/deletedialog/view/templates/default/deletedialog/approve_status.tpl.php
+++ b/contributions/deletedialog/view/templates/default/deletedialog/approve_status.tpl.php
@@ -14,7 +14,7 @@ $page_data->head->title = $title;
 $page_data->breadcrumb = WidgetBreadcrumb::output(
 	array(
 		$instance,
-		tr('Delete', 'deletedialog')
+		GyroString::escape(tr('Delete', 'deletedialog'))
 	)
 );
 ?>

--- a/contributions/usermanagement.notifications/view/templates/default/notifications/my.tpl.php
+++ b/contributions/usermanagement.notifications/view/templates/default/notifications/my.tpl.php
@@ -1,7 +1,7 @@
 <?php
 $title = tr('Your Notifications', 'notifications');
 $page_data->head->title = $title;
-$page_data->breadcrumb = WidgetBreadcrumb::output($title);
+$page_data->breadcrumb = WidgetBreadcrumb::output(GyroString::escape($title));
 ?>
 <h1><?=$title?></h1>
 

--- a/contributions/usermanagement.notifications/view/templates/default/notifications/settings.tpl.php
+++ b/contributions/usermanagement.notifications/view/templates/default/notifications/settings.tpl.php
@@ -6,7 +6,7 @@ $title = tr('Notification Settings', 'notifications');
 $page_data->head->title = $title;
 $page_data->breadcrumb = WidgetBreadcrumb::output(array(
 	WidgetActionLink::output(tr('Your Notifications', 'notifications'), 'users_notifications'),
-	tr('Settings', 'notifications')
+	GyroString::escape(tr('Settings', 'notifications'))
 ));
 ?>
 <h1><?=$title?></h1>

--- a/contributions/usermanagement/view/templates/default/users/create.tpl.php
+++ b/contributions/usermanagement/view/templates/default/users/create.tpl.php
@@ -4,7 +4,7 @@ $page_data->head->title = $title;
 $page_data->breadcrumb = WidgetBreadcrumb::output(
 	array(
 		WidgetActionLink::output('Users', 'users_list_all'),
-		$title
+		GyroString::escape($title)
 	)
 );
 ?>

--- a/contributions/usermanagement/view/templates/default/users/dashboard.tpl.php
+++ b/contributions/usermanagement/view/templates/default/users/dashboard.tpl.php
@@ -3,7 +3,7 @@ $page_title = tr('Welcome %name', 'users', array('%name' => $current_user->name)
 $page_data->head->robots_index = ROBOTS_NOINDEX;
 $page_data->head->title = $page_title; 
 $page_data->breadcrumb = WidgetBreadcrumb::output(
-	tr('Your personal site', 'users')
+	GyroString::escape(tr('Your personal site', 'users'))
 );
 ?>
 

--- a/contributions/usermanagement/view/templates/default/users/edit_self.tpl.php
+++ b/contributions/usermanagement/view/templates/default/users/edit_self.tpl.php
@@ -2,7 +2,7 @@
 /* @var $page_data PageData */
 $page_data->head->title = tr('Edit your account settings', 'users');
 $page_data->breadcrumb = WidgetBreadcrumb::output(array(
-	tr('Change Account Data', 'users')
+	GyroString::escape(tr('Change Account Data', 'users'))
 ))
 ?>
 <h1><?=tr('Change Account Data', 'users')?></h1>

--- a/contributions/usermanagement/view/templates/default/users/list.tpl.php
+++ b/contributions/usermanagement/view/templates/default/users/list.tpl.php
@@ -4,7 +4,7 @@ $page_data->head->description = tr('List of all users known to the system.', 'us
 
 $title = tr('Users List', 'users');
 $page_data->breadcrumb = WidgetBreadcrumb::output(
-	$title
+	GyroString::escape($title)
 );
 ?>
 <h1><?=$title?></h1>

--- a/contributions/usermanagement/view/templates/default/users/login.tpl.php
+++ b/contributions/usermanagement/view/templates/default/users/login.tpl.php
@@ -3,7 +3,7 @@ $page_data->head->robots_index = ROBOTS_NOINDEX_FOLLOW;
 $title = tr('Login', 'users');
 $page_data->head->title = $title;
 $page_data->breadcrumb = WidgetBreadcrumb::output(
-	$title
+	GyroString::escape($title)
 );
 ?>
 <h1><?=$title?></h1>

--- a/contributions/usermanagement/view/templates/default/users/lost_password.tpl.php
+++ b/contributions/usermanagement/view/templates/default/users/lost_password.tpl.php
@@ -3,7 +3,7 @@ $page_data->head->robots_index = ROBOTS_NOINDEX_FOLLOW;
 $title = tr('Lost Password', 'users');
 $page_data->head->title = $title;
 $page_data->breadcrumb = WidgetBreadcrumb::output(
-	$title
+	GyroString::escape($title)
 );
 ?>
 <h1><?=$title?></h1>

--- a/contributions/usermanagement/view/templates/default/users/register.tpl.php
+++ b/contributions/usermanagement/view/templates/default/users/register.tpl.php
@@ -3,7 +3,7 @@ $page_data->head->robots_index = ROBOTS_NOINDEX_FOLLOW;
 $title = tr('Become a member', 'users');
 $page_data->head->title = $title;
 $page_data->breadcrumb = WidgetBreadcrumb::output(
-	$title
+	GyroString::escape($title)
 );?>
 
 <h1><?=$title;?></h1>

--- a/contributions/usermanagement/view/templates/default/users/resend_registration_mail.tpl.php
+++ b/contributions/usermanagement/view/templates/default/users/resend_registration_mail.tpl.php
@@ -4,7 +4,7 @@ $page_data->head->title = $title;
 $page_data->head->robots_index = ROBOTS_NOINDEX_FOLLOW;
 
 $page_data->breadcrumb = WidgetBreadcrumb::output(
-	$title
+	GyroString::escape($title)
 );
 ?>
 <h1><?=$title?></h1>

--- a/gyro/core/view/widgets/actionlink.widget.php
+++ b/gyro/core/view/widgets/actionlink.widget.php
@@ -14,7 +14,7 @@ class WidgetActionLink implements IWidget {
 	/**
 	 * @param string|ISelfDescribing $text The content of the anchor to create. Gets escaped if instance of ISelfDescribing, else it is printed as given
 	 * @param string $action The action to retrieve URL for
-	 * @param array|null $params The parameters for aboev action
+	 * @param array|null $params The parameters for above action
 	 * @param array $html_attrs Attributes to pass to HTML anchor. If a gyro_query is passed, this is added as query to the generated action URL
 	 * @return string
 	 */


### PR DESCRIPTION
Breadcrumb output can contain illegal html characters with yet unknown translations, so better we always escape