### PR TITLE
hijack action should only granted on active users

### DIFF
--- a/contributions/usermanagement.hijackaccount/behaviour/accesscontrol/hijackaccount.access.php
+++ b/contributions/usermanagement.hijackaccount/behaviour/accesscontrol/hijackaccount.access.php
@@ -26,7 +26,7 @@ class HijackaccountAccessControl extends AccessControlBase {
 		switch ($action) {
 			case 'hijack':
 				// Admins are allowed to hijack
-				$ret = $this->to_result($user->has_role(USER_ROLE_ADMIN));
+				$ret = $this->to_result($user->has_role(USER_ROLE_ADMIN) && $item->is_active());
 				break;
 		}
 		return $ret;


### PR DESCRIPTION
because hijacking / login is not possible on inactive accounts.